### PR TITLE
feat: add exact out definitions

### DIFF
--- a/solidity/contracts/TransformerRegistry.sol
+++ b/solidity/contracts/TransformerRegistry.sol
@@ -110,14 +110,14 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient
-  ) external payable returns (uint256 _spentDependent) {}
+  ) external returns (uint256 _spentDependent) {}
 
   /// @inheritdoc ITransformer
   function transformToExpectedDependent(
     address _dependent,
     uint256 _expectedDependent,
     address _recipient
-  ) external returns (UnderlyingAmount[] memory _spentUnderlying) {}
+  ) external payable returns (UnderlyingAmount[] memory _spentUnderlying) {}
 
   receive() external payable {}
 

--- a/solidity/contracts/TransformerRegistry.sol
+++ b/solidity/contracts/TransformerRegistry.sol
@@ -64,6 +64,20 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
   }
 
   /// @inheritdoc ITransformer
+  function calculateNeededToTransformToUnderlying(address _dependent, UnderlyingAmount[] calldata _expectedUnderlying)
+    external
+    view
+    returns (uint256 _neededDependent)
+  {}
+
+  /// @inheritdoc ITransformer
+  function calculateNeededToTransformToDependent(address _dependent, uint256 _expectedDependent)
+    external
+    view
+    returns (UnderlyingAmount[] memory _neededUnderlying)
+  {}
+
+  /// @inheritdoc ITransformer
   function transformToUnderlying(
     address _dependent,
     uint256 _amountDependent,
@@ -90,6 +104,20 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     );
     return abi.decode(_result, (uint256));
   }
+
+  /// @inheritdoc ITransformer
+  function transformToExpectedUnderlying(
+    address _dependent,
+    UnderlyingAmount[] calldata _expectedUnderlying,
+    address _recipient
+  ) external payable returns (uint256 _spentDependent) {}
+
+  /// @inheritdoc ITransformer
+  function transformToExpectedDependent(
+    address _dependent,
+    uint256 _expectedDependent,
+    address _recipient
+  ) external returns (UnderlyingAmount[] memory _spentUnderlying) {}
 
   receive() external payable {}
 

--- a/solidity/contracts/transformers/ERC4626Transformer.sol
+++ b/solidity/contracts/transformers/ERC4626Transformer.sol
@@ -35,6 +35,20 @@ contract ERC4626Transformer is BaseTransformer {
   }
 
   /// @inheritdoc ITransformer
+  function calculateNeededToTransformToUnderlying(address _dependent, UnderlyingAmount[] calldata _expectedUnderlying)
+    external
+    view
+    returns (uint256 _neededDependent)
+  {}
+
+  /// @inheritdoc ITransformer
+  function calculateNeededToTransformToDependent(address _dependent, uint256 _expectedDependent)
+    external
+    view
+    returns (UnderlyingAmount[] memory _neededUnderlying)
+  {}
+
+  /// @inheritdoc ITransformer
   function transformToUnderlying(
     address _dependent,
     uint256 _amountDependent,
@@ -58,6 +72,20 @@ contract ERC4626Transformer is BaseTransformer {
     _underlyingToken.approve(_dependent, _underlyingAmount);
     _amountDependent = IERC4626(_dependent).deposit(_underlyingAmount, _recipient);
   }
+
+  /// @inheritdoc ITransformer
+  function transformToExpectedUnderlying(
+    address _dependent,
+    UnderlyingAmount[] calldata _expectedUnderlying,
+    address _recipient
+  ) external payable returns (uint256 _spentDependent) {}
+
+  /// @inheritdoc ITransformer
+  function transformToExpectedDependent(
+    address _dependent,
+    uint256 _expectedDependent,
+    address _recipient
+  ) external returns (UnderlyingAmount[] memory _spentUnderlying) {}
 
   function _toUnderlying(address _underlying) internal pure returns (address[] memory _underlyingArray) {
     _underlyingArray = new address[](1);

--- a/solidity/contracts/transformers/ERC4626Transformer.sol
+++ b/solidity/contracts/transformers/ERC4626Transformer.sol
@@ -78,14 +78,14 @@ contract ERC4626Transformer is BaseTransformer {
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient
-  ) external payable returns (uint256 _spentDependent) {}
+  ) external returns (uint256 _spentDependent) {}
 
   /// @inheritdoc ITransformer
   function transformToExpectedDependent(
     address _dependent,
     uint256 _expectedDependent,
     address _recipient
-  ) external returns (UnderlyingAmount[] memory _spentUnderlying) {}
+  ) external payable returns (UnderlyingAmount[] memory _spentUnderlying) {}
 
   function _toUnderlying(address _underlying) internal pure returns (address[] memory _underlyingArray) {
     _underlyingArray = new address[](1);

--- a/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
+++ b/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
@@ -69,14 +69,14 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient
-  ) external payable returns (uint256 _spentDependent) {}
+  ) external returns (uint256 _spentDependent) {}
 
   /// @inheritdoc ITransformer
   function transformToExpectedDependent(
     address _dependent,
     uint256 _expectedDependent,
     address _recipient
-  ) external returns (UnderlyingAmount[] memory _spentUnderlying) {}
+  ) external payable returns (UnderlyingAmount[] memory _spentUnderlying) {}
 
   receive() external payable {}
 

--- a/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
+++ b/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
@@ -28,6 +28,20 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
   }
 
   /// @inheritdoc ITransformer
+  function calculateNeededToTransformToUnderlying(address _dependent, UnderlyingAmount[] calldata _expectedUnderlying)
+    external
+    view
+    returns (uint256 _neededDependent)
+  {}
+
+  /// @inheritdoc ITransformer
+  function calculateNeededToTransformToDependent(address _dependent, uint256 _expectedDependent)
+    external
+    view
+    returns (UnderlyingAmount[] memory _neededUnderlying)
+  {}
+
+  /// @inheritdoc ITransformer
   function transformToUnderlying(
     address _dependent,
     uint256 _amountDependent,
@@ -49,6 +63,20 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     IWETH9(_dependent).deposit{value: _amountDependent}();
     IERC20(_dependent).safeTransfer(_recipient, _amountDependent);
   }
+
+  /// @inheritdoc ITransformer
+  function transformToExpectedUnderlying(
+    address _dependent,
+    UnderlyingAmount[] calldata _expectedUnderlying,
+    address _recipient
+  ) external payable returns (uint256 _spentDependent) {}
+
+  /// @inheritdoc ITransformer
+  function transformToExpectedDependent(
+    address _dependent,
+    uint256 _expectedDependent,
+    address _recipient
+  ) external returns (UnderlyingAmount[] memory _spentUnderlying) {}
 
   receive() external payable {}
 

--- a/solidity/interfaces/ITransformer.sol
+++ b/solidity/interfaces/ITransformer.sol
@@ -51,6 +51,34 @@ interface ITransformer {
     returns (uint256 amountDependent);
 
   /**
+   * @notice Calculates how many dependent tokens are needed to transform to the expected
+   *         amount of underlying
+   * @dev This function must be unaware of context. The returned values must be the same,
+   *      regardless of who the caller is
+   * @param dependent The address of the dependent token
+   * @param expectedUnderlying The expected amounts of underlying tokens
+   * @return neededDependent The amount of dependent needed
+   */
+  function calculateNeededToTransformToUnderlying(address dependent, UnderlyingAmount[] calldata expectedUnderlying)
+    external
+    view
+    returns (uint256 neededDependent);
+
+  /**
+   * @notice Calculates how many underlying tokens are needed to transform to the expected
+   *         amount of dependent
+   * @dev This function must be unaware of context. The returned values must be the same,
+   *      regardless of who the caller is
+   * @param dependent The address of the dependent token
+   * @param expectedDependent The expected amount of dependent tokens
+   * @return neededUnderlying The amount of underlying tokens needed
+   */
+  function calculateNeededToTransformToDependent(address dependent, uint256 expectedDependent)
+    external
+    view
+    returns (UnderlyingAmount[] memory neededUnderlying);
+
+  /**
    * @notice Executes the transformation to the underlying tokens
    * @param dependent The address of the dependent token
    * @param amountDependent The amount to transform
@@ -75,4 +103,30 @@ interface ITransformer {
     UnderlyingAmount[] calldata underlying,
     address recipient
   ) external payable returns (uint256 amountDependent);
+
+  /**
+   * @notice Transforms dependent tokens to an expected amount of underlying tokens
+   * @param dependent The address of the dependent token
+   * @param expectedUnderlying The expected amounts of underlying tokens
+   * @param recipient The address that would receive the underlying tokens
+   * @return spentDependent The amount of spent dependent tokens
+   */
+  function transformToExpectedUnderlying(
+    address dependent,
+    UnderlyingAmount[] calldata expectedUnderlying,
+    address recipient
+  ) external payable returns (uint256 spentDependent);
+
+  /**
+   * @notice Transforms underlying tokens to an expected amount of dependent tokens
+   * @param dependent The address of the dependent token
+   * @param expectedDependent The expected amounts of dependent tokens
+   * @param recipient The address that would receive the underlying tokens
+   * @return spentUnderlying The amount of spent underlying tokens
+   */
+  function transformToExpectedDependent(
+    address dependent,
+    uint256 expectedDependent,
+    address recipient
+  ) external returns (UnderlyingAmount[] memory spentUnderlying);
 }

--- a/solidity/interfaces/ITransformer.sol
+++ b/solidity/interfaces/ITransformer.sol
@@ -115,7 +115,7 @@ interface ITransformer {
     address dependent,
     UnderlyingAmount[] calldata expectedUnderlying,
     address recipient
-  ) external payable returns (uint256 spentDependent);
+  ) external returns (uint256 spentDependent);
 
   /**
    * @notice Transforms underlying tokens to an expected amount of dependent tokens
@@ -128,5 +128,5 @@ interface ITransformer {
     address dependent,
     uint256 expectedDependent,
     address recipient
-  ) external returns (UnderlyingAmount[] memory spentUnderlying);
+  ) external payable returns (UnderlyingAmount[] memory spentUnderlying);
 }


### PR DESCRIPTION
We are now adding 'exact out' transformations. We want the transformation to output a specific amount, and only the necessary amount of input should be used