### PR TITLE
feat: protocol transformer calculate needed

### DIFF
--- a/slither.config.json
+++ b/slither.config.json
@@ -1,4 +1,4 @@
 {
-  "detectors_to_exclude": "solc-version",
+  "detectors_to_exclude": "conformance-to-solidity-naming-conventions,solc-version",
   "filter_paths": "node_modules|openzeppelin"
 }

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,4 +1,4 @@
 {
-  "detectors_to_exclude": "conformance-to-solidity-naming-conventions",
+  "detectors_to_exclude": "solc-version",
   "filter_paths": "node_modules|openzeppelin"
 }

--- a/solidity/contracts/test/utils/Multicall.sol
+++ b/solidity/contracts/test/utils/Multicall.sol
@@ -5,6 +5,7 @@ pragma solidity >=0.8.7 <0.9.0;
 import '../../utils/Multicall.sol';
 
 contract MulticallMock is Multicall {
+  // slither-disable-next-line arbitrary-send
   function sendEthToAddress(address payable _recipient, uint256 _amount) external payable {
     _recipient.transfer(_amount);
   }

--- a/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
+++ b/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
@@ -46,6 +46,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
   }
 
   /// @inheritdoc ITransformer
+  // slither-disable-next-line arbitrary-send
   function transformToUnderlying(
     address _dependent,
     uint256 _amountDependent,
@@ -58,6 +59,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
   }
 
   /// @inheritdoc ITransformer
+  // slither-disable-next-line arbitrary-send
   function transformToDependent(
     address _dependent,
     UnderlyingAmount[] calldata _underlying,

--- a/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
+++ b/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
@@ -28,18 +28,22 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
   }
 
   /// @inheritdoc ITransformer
-  function calculateNeededToTransformToUnderlying(address _dependent, UnderlyingAmount[] calldata _expectedUnderlying)
+  function calculateNeededToTransformToUnderlying(address, UnderlyingAmount[] calldata _expectedUnderlying)
     external
-    view
+    pure
     returns (uint256 _neededDependent)
-  {}
+  {
+    _neededDependent = _expectedUnderlying[0].amount;
+  }
 
   /// @inheritdoc ITransformer
-  function calculateNeededToTransformToDependent(address _dependent, uint256 _expectedDependent)
+  function calculateNeededToTransformToDependent(address, uint256 _expectedDependent)
     external
-    view
+    pure
     returns (UnderlyingAmount[] memory _neededUnderlying)
-  {}
+  {
+    return _toUnderylingAmount(PROTOCOL_TOKEN, _expectedDependent);
+  }
 
   /// @inheritdoc ITransformer
   function transformToUnderlying(

--- a/test/unit/transformers/protocol-token-wrapper-transformer.spec.ts
+++ b/test/unit/transformers/protocol-token-wrapper-transformer.spec.ts
@@ -85,6 +85,34 @@ describe('ProtocolTokenWrapperTransformer', () => {
     });
   });
 
+  describe('calculateNeededToTransformToUnderlying', () => {
+    when('function is called', () => {
+      let neededDependent: BigNumber;
+      given(async () => {
+        neededDependent = await transformer.calculateNeededToTransformToUnderlying(wToken.address, [
+          { underlying: PROTOCOL_TOKEN, amount: AMOUNT_TO_MAP },
+        ]);
+      });
+      then('needed dependent is returned correctly', async () => {
+        expect(neededDependent).to.equal(AMOUNT_TO_MAP);
+      });
+    });
+  });
+
+  describe('calculateNeededToTransformToDependent', () => {
+    when('function is called', () => {
+      let neededUnderlying: ITransformer.UnderlyingAmountStructOutput[];
+      given(async () => {
+        neededUnderlying = await transformer.calculateNeededToTransformToDependent(wToken.address, AMOUNT_TO_MAP);
+      });
+      then('needed underlying is returned correctly', async () => {
+        expect(neededUnderlying.length).to.equal(1);
+        expect(neededUnderlying[0].amount).to.equal(AMOUNT_TO_MAP);
+        expect(neededUnderlying[0].underlying).to.equal(PROTOCOL_TOKEN);
+      });
+    });
+  });
+
   describe('transformToUnderlying', () => {
     when('function is called', () => {
       given(async () => {


### PR DESCRIPTION
We are now implementing `calculateNeededToTransformToUnderlying` and `calculateNeededToTransformToDependent` for `ProtocolTokenWrapperTransformer`