### PR TITLE
feat: registry add calculate expected

### DIFF
--- a/solidity/contracts/TransformerRegistry.sol
+++ b/solidity/contracts/TransformerRegistry.sol
@@ -68,14 +68,20 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     external
     view
     returns (uint256 _neededDependent)
-  {}
+  {
+    ITransformer _transformer = _getTransformerOrFail(_dependent);
+    return _transformer.calculateNeededToTransformToUnderlying(_dependent, _expectedUnderlying);
+  }
 
   /// @inheritdoc ITransformer
   function calculateNeededToTransformToDependent(address _dependent, uint256 _expectedDependent)
     external
     view
     returns (UnderlyingAmount[] memory _neededUnderlying)
-  {}
+  {
+    ITransformer _transformer = _getTransformerOrFail(_dependent);
+    return _transformer.calculateNeededToTransformToDependent(_dependent, _expectedDependent);
+  }
 
   /// @inheritdoc ITransformer
   function transformToUnderlying(

--- a/test/unit/transformer-registry.spec.ts
+++ b/test/unit/transformer-registry.spec.ts
@@ -149,6 +149,18 @@ describe('TransformerRegistry', () => {
     returns: DEPENDENT_AMOUNT,
   });
 
+  delegateViewTest({
+    method: 'calculateNeededToTransformToUnderlying',
+    args: (dependent) => [dependent, UNDERLYING_AMOUNT],
+    returns: DEPENDENT_AMOUNT,
+  });
+
+  delegateViewTest({
+    method: 'calculateNeededToTransformToDependent',
+    args: (dependent) => [dependent, DEPENDENT_AMOUNT],
+    returns: UNDERLYING_AMOUNT as any,
+  });
+
   describe('transformToUnderlying', () => {
     assertFailsWithUnknownDependent('transformToUnderlying', (dependent) => [
       dependent,


### PR DESCRIPTION
We are now implementing `calculateNeededToTransformToUnderlying` and `calculateNeededToTransformToDependent` for`TransformerRegistry`