### PR TITLE
feat: registry add transform expected

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@codechecks/client": "0.1.12",
     "@commitlint/cli": "16.2.4",
     "@commitlint/config-conventional": "16.2.4",
-    "@defi-wonderland/smock": "2.0.7",
+    "@defi-wonderland/smock": "2.2.0",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@0.3.0-beta.13",
     "@nomiclabs/hardhat-etherscan": "3.0.3",
     "@nomiclabs/hardhat-waffle": "2.0.3",

--- a/solidity/contracts/TransformerRegistry.sol
+++ b/solidity/contracts/TransformerRegistry.sol
@@ -116,14 +116,28 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient
-  ) external returns (uint256 _spentDependent) {}
+  ) external returns (uint256 _spentDependent) {
+    ITransformer _transformer = _getTransformerOrFail(_dependent);
+    bytes memory _result = _delegateToTransformer(
+      _transformer,
+      abi.encodeWithSelector(_transformer.transformToExpectedUnderlying.selector, _dependent, _expectedUnderlying, _recipient)
+    );
+    return abi.decode(_result, (uint256));
+  }
 
   /// @inheritdoc ITransformer
   function transformToExpectedDependent(
     address _dependent,
     uint256 _expectedDependent,
     address _recipient
-  ) external payable returns (UnderlyingAmount[] memory _spentUnderlying) {}
+  ) external payable returns (UnderlyingAmount[] memory _spentUnderlying) {
+    ITransformer _transformer = _getTransformerOrFail(_dependent);
+    bytes memory _result = _delegateToTransformer(
+      _transformer,
+      abi.encodeWithSelector(_transformer.transformToExpectedDependent.selector, _dependent, _expectedDependent, _recipient)
+    );
+    return abi.decode(_result, (UnderlyingAmount[]));
+  }
 
   receive() external payable {}
 

--- a/test/unit/transformer-registry.spec.ts
+++ b/test/unit/transformer-registry.spec.ts
@@ -161,50 +161,42 @@ describe('TransformerRegistry', () => {
     returns: UNDERLYING_AMOUNT as any,
   });
 
-  describe('transformToUnderlying', () => {
-    delegateTest({
-      method: 'transformToUnderlying',
-      args: (dependent) => [dependent, DEPENDENT_AMOUNT, '0x0000000000000000000000000000000000000002'],
-      returns: UNDERLYING_AMOUNT as any,
-    });
+  delegateTest({
+    method: 'transformToUnderlying',
+    args: (dependent) => [dependent, DEPENDENT_AMOUNT, '0x0000000000000000000000000000000000000002'],
+    returns: UNDERLYING_AMOUNT as any,
   });
 
-  describe('transformToDependent', () => {
-    delegateTest({
-      method: 'transformToDependent',
-      args: (dependent) => [dependent, UNDERLYING_AMOUNT, '0x0000000000000000000000000000000000000002'],
-      returns: DEPENDENT_AMOUNT,
-      specialArgAssertion: (args) => {
-        expect(args[0]).to.equal(DEPENDENT);
-        expect(args[1]).to.have.lengthOf(1);
-        expect(args[1][0].underlying).to.equal(UNDERLYING_AMOUNT[0].underlying);
-        expect(args[1][0].amount).to.equal(UNDERLYING_AMOUNT[0].amount);
-        expect(args[2]).to.equal('0x0000000000000000000000000000000000000002');
-      },
-    });
+  delegateTest({
+    method: 'transformToDependent',
+    args: (dependent) => [dependent, UNDERLYING_AMOUNT, '0x0000000000000000000000000000000000000002'],
+    returns: DEPENDENT_AMOUNT,
+    specialArgAssertion: (args) => {
+      expect(args[0]).to.equal(DEPENDENT);
+      expect(args[1]).to.have.lengthOf(1);
+      expect(args[1][0].underlying).to.equal(UNDERLYING_AMOUNT[0].underlying);
+      expect(args[1][0].amount).to.equal(UNDERLYING_AMOUNT[0].amount);
+      expect(args[2]).to.equal('0x0000000000000000000000000000000000000002');
+    },
   });
 
-  describe('transformToExpectedUnderlying', () => {
-    delegateTest({
-      method: 'transformToExpectedUnderlying',
-      args: (dependent) => [dependent, UNDERLYING_AMOUNT, '0x0000000000000000000000000000000000000002'],
-      returns: DEPENDENT_AMOUNT,
-      specialArgAssertion: (args) => {
-        expect(args[0]).to.equal(DEPENDENT);
-        expect(args[1]).to.have.lengthOf(1);
-        expect(args[1][0].underlying).to.equal(UNDERLYING_AMOUNT[0].underlying);
-        expect(args[1][0].amount).to.equal(UNDERLYING_AMOUNT[0].amount);
-        expect(args[2]).to.equal('0x0000000000000000000000000000000000000002');
-      },
-    });
+  delegateTest({
+    method: 'transformToExpectedUnderlying',
+    args: (dependent) => [dependent, UNDERLYING_AMOUNT, '0x0000000000000000000000000000000000000002'],
+    returns: DEPENDENT_AMOUNT,
+    specialArgAssertion: (args) => {
+      expect(args[0]).to.equal(DEPENDENT);
+      expect(args[1]).to.have.lengthOf(1);
+      expect(args[1][0].underlying).to.equal(UNDERLYING_AMOUNT[0].underlying);
+      expect(args[1][0].amount).to.equal(UNDERLYING_AMOUNT[0].amount);
+      expect(args[2]).to.equal('0x0000000000000000000000000000000000000002');
+    },
   });
 
-  describe('transformToExpectedDependent', () => {
-    delegateTest({
-      method: 'transformToExpectedDependent',
-      args: (dependent) => [dependent, DEPENDENT_AMOUNT, '0x0000000000000000000000000000000000000002'],
-      returns: UNDERLYING_AMOUNT as any,
-    });
+  delegateTest({
+    method: 'transformToExpectedDependent',
+    args: (dependent) => [dependent, DEPENDENT_AMOUNT, '0x0000000000000000000000000000000000000002'],
+    returns: UNDERLYING_AMOUNT as any,
   });
 
   function delegateViewTest<Method extends keyof Functions>({

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,10 +255,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@defi-wonderland/smock@2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@defi-wonderland/smock/-/smock-2.0.7.tgz#59d5fc93e175ad120c5dcdd8294e07525606c855"
-  integrity sha512-RVpODLKZ/Cr0C1bCbhJ2aXbAr2Ll/K2WO7hDL96tqhMzCsA7ToWdDIgiNpV5Vtqqvpftu5ddO7v3TAurQNSU0w==
+"@defi-wonderland/smock@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@defi-wonderland/smock/-/smock-2.2.0.tgz#26bd818eb469b6015ab52193d8253cf92b702baa"
+  integrity sha512-LbEufBtfSZAzRjusDF3ZovbYfWbsPKZrKcR2+0KW8h7DE6I79ZuDDE+/lQUyKqMk4KaWQ02zSqpRsQuIhovvHg==
   dependencies:
     "@nomiclabs/ethereumjs-vm" "^4.2.2"
     diff "^5.0.0"


### PR DESCRIPTION
We are now implementing `transformToExpectedUnderlying` and `transformToExpectedDependent` for `TransformerRegistry`