### PR TITLE
feat: add transform all to underlying

### DIFF
--- a/solidity/contracts/TransformerRegistry.sol
+++ b/solidity/contracts/TransformerRegistry.sol
@@ -112,6 +112,17 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
   }
 
   /// @inheritdoc ITransformer
+  function transformAllToUnderlying(address _dependent, address _recipient) external returns (UnderlyingAmount[] memory) {
+    ITransformer _transformer = _getTransformerOrFail(_dependent);
+    uint256 _amountDependent = IERC20(_dependent).balanceOf(msg.sender);
+    bytes memory _result = _delegateToTransformer(
+      _transformer,
+      abi.encodeWithSelector(_transformer.transformToUnderlying.selector, _dependent, _amountDependent, _recipient)
+    );
+    return abi.decode(_result, (UnderlyingAmount[]));
+  }
+
+  /// @inheritdoc ITransformer
   function transformToExpectedUnderlying(
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,

--- a/solidity/contracts/TransformerRegistry.sol
+++ b/solidity/contracts/TransformerRegistry.sol
@@ -111,7 +111,7 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     return abi.decode(_result, (uint256));
   }
 
-  /// @inheritdoc ITransformer
+  /// @inheritdoc ITransformerRegistry
   function transformAllToUnderlying(address _dependent, address _recipient) external returns (UnderlyingAmount[] memory) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     uint256 _amountDependent = IERC20(_dependent).balanceOf(msg.sender);

--- a/solidity/interfaces/ITransformerRegistry.sol
+++ b/solidity/interfaces/ITransformerRegistry.sol
@@ -61,4 +61,13 @@ interface ITransformerRegistry is ITransformer {
    * @param dependents The associations to remove
    */
   function removeTransformers(address[] calldata dependents) external;
+
+  /**
+   * @notice Executes a transformation to the underlying tokens, by taking the caller's entire
+   *         dependent balance. This is meant to be used as part of a multi-hop swap
+   * @param dependent The address of the dependent token
+   * @param recipient The address that would receive the underlying tokens
+   * @return The transformed amount in each of the underlying tokens
+   */
+  function transformAllToUnderlying(address dependent, address recipient) external returns (UnderlyingAmount[] memory);
 }

--- a/test/unit/transformer-registry.spec.ts
+++ b/test/unit/transformer-registry.spec.ts
@@ -16,34 +16,39 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { behaviours } from '@utils';
 import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { readArgFromEventOrFail } from '@utils/event-utils';
+import { IERC20 } from '@mean-finance/deterministic-factory/typechained';
 const { makeInterfaceId } = require('@openzeppelin/test-helpers');
 
 chai.use(smock.matchers);
 
 describe('TransformerRegistry', () => {
-  const DEPENDENT = '0x0000000000000000000000000000000000000001';
   const ERC_165_INTERFACE_ID = getInterfaceId(ERC165__factory.createInterface());
   const TRANSFORMER_INTERFACE_ID = getInterfaceId(ITransformer__factory.createInterface());
   const DEPENDENT_AMOUNT = BigNumber.from(10000);
   const UNDERLYING_AMOUNT = [{ underlying: constants.AddressZero, amount: DEPENDENT_AMOUNT }];
+  const RECIPIENT = '0x0000000000000000000000000000000000000002';
 
-  let governor: SignerWithAddress;
+  let signer: SignerWithAddress, governor: SignerWithAddress;
   let transformer: FakeContract<ITransformerERC165>;
   let registry: TransformerRegistry;
+  let dependent: FakeContract<IERC20>;
   let snapshotId: string;
 
   before('Setup accounts and contracts', async () => {
-    [, governor] = await ethers.getSigners();
+    [signer, governor] = await ethers.getSigners();
     transformer = await smock.fake('ITransformerERC165');
     const factory: TransformerRegistry__factory = await ethers.getContractFactory(
       'solidity/contracts/TransformerRegistry.sol:TransformerRegistry'
     );
     registry = await factory.deploy(governor.address);
+    dependent = await smock.fake('IERC20');
     snapshotId = await snapshot.take();
   });
 
   beforeEach(async () => {
     await snapshot.revert(snapshotId);
+    dependent.balanceOf.reset();
+    transformer.transformToUnderlying.reset();
     transformer.supportsInterface.reset();
     transformer.supportsInterface.returns(
       ({ interfaceId }: { interfaceId: string }) => interfaceId === ERC_165_INTERFACE_ID || interfaceId === TRANSFORMER_INTERFACE_ID
@@ -56,7 +61,7 @@ describe('TransformerRegistry', () => {
         await behaviours.txShouldRevertWithMessage({
           contract: registry.connect(governor),
           func: 'registerTransformers',
-          args: [[{ transformer: constants.AddressZero, dependents: [DEPENDENT] }]],
+          args: [[{ transformer: constants.AddressZero, dependents: [dependent.address] }]],
           message: `AddressIsNotTransformer`,
         });
       });
@@ -69,7 +74,7 @@ describe('TransformerRegistry', () => {
         await behaviours.txShouldRevertWithMessage({
           contract: registry.connect(governor),
           func: 'registerTransformers',
-          args: [[{ transformer: transformer.address, dependents: [DEPENDENT] }]],
+          args: [[{ transformer: transformer.address, dependents: [dependent.address] }]],
           message: `AddressIsNotTransformer`,
         });
       });
@@ -77,7 +82,7 @@ describe('TransformerRegistry', () => {
     when('given transformer implements ITransformer', () => {
       let tx: TransactionResponse;
       given(async () => {
-        tx = await registry.connect(governor).registerTransformers([{ transformer: transformer.address, dependents: [DEPENDENT] }]);
+        tx = await registry.connect(governor).registerTransformers([{ transformer: transformer.address, dependents: [dependent.address] }]);
       });
       then('transformer is called correctly', () => {
         expect(transformer.supportsInterface).to.have.been.calledThrice;
@@ -86,7 +91,7 @@ describe('TransformerRegistry', () => {
         expect(transformer.supportsInterface).to.have.been.calledWith(TRANSFORMER_INTERFACE_ID);
       });
       then('dependents are registered correctly', async () => {
-        const transformers = await registry.transformers([DEPENDENT]);
+        const transformers = await registry.transformers([dependent.address]);
         expect(transformers).to.eql([transformer.address]);
       });
       then('event is emitted', async () => {
@@ -97,13 +102,13 @@ describe('TransformerRegistry', () => {
         );
         expect(registrations.length).to.equal(1);
         expect(registrations[0].transformer).to.equal(transformer.address);
-        expect(registrations[0].dependents).to.eql([DEPENDENT]);
+        expect(registrations[0].dependents).to.eql([dependent.address]);
       });
     });
     behaviours.shouldBeExecutableOnlyByGovernor({
       contract: () => registry,
       funcAndSignature: 'registerTransformers',
-      params: () => [[{ transformer: transformer.address, dependents: [DEPENDENT] }]],
+      params: () => [[{ transformer: transformer.address, dependents: [dependent.address] }]],
       governor: () => governor,
     });
   });
@@ -112,90 +117,114 @@ describe('TransformerRegistry', () => {
     when('removing transformers', () => {
       let tx: TransactionResponse;
       given(async () => {
-        await registry.connect(governor).registerTransformers([{ transformer: transformer.address, dependents: [DEPENDENT] }]);
-        tx = await registry.connect(governor).removeTransformers([DEPENDENT]);
+        await registry.connect(governor).registerTransformers([{ transformer: transformer.address, dependents: [dependent.address] }]);
+        tx = await registry.connect(governor).removeTransformers([dependent.address]);
       });
       then('dependents are removed correctly', async () => {
-        const transformers = await registry.transformers([DEPENDENT]);
+        const transformers = await registry.transformers([dependent.address]);
         expect(transformers).to.eql([constants.AddressZero]);
       });
       then('event is emitted', async () => {
-        await expect(tx).to.emit(registry, 'TransformersRemoved').withArgs([DEPENDENT]);
+        await expect(tx).to.emit(registry, 'TransformersRemoved').withArgs([dependent.address]);
       });
     });
     behaviours.shouldBeExecutableOnlyByGovernor({
       contract: () => registry,
       funcAndSignature: 'removeTransformers',
-      params: () => [[DEPENDENT]],
+      params: () => [[dependent.address]],
       governor: () => governor,
     });
   });
 
   delegateViewTest({
     method: 'getUnderlying',
-    args: (dependent) => [dependent],
-    returns: ['0x0000000000000000000000000000000000000002'],
+    args: () => [dependent.address],
+    returns: [RECIPIENT],
   });
 
   delegateViewTest({
     method: 'calculateTransformToUnderlying',
-    args: (dependent) => [dependent, DEPENDENT_AMOUNT],
+    args: () => [dependent.address, DEPENDENT_AMOUNT],
     returns: UNDERLYING_AMOUNT as any,
   });
 
   delegateViewTest({
     method: 'calculateTransformToDependent',
-    args: (dependent) => [dependent, UNDERLYING_AMOUNT],
+    args: () => [dependent.address, UNDERLYING_AMOUNT],
     returns: DEPENDENT_AMOUNT,
   });
 
   delegateViewTest({
     method: 'calculateNeededToTransformToUnderlying',
-    args: (dependent) => [dependent, UNDERLYING_AMOUNT],
+    args: () => [dependent.address, UNDERLYING_AMOUNT],
     returns: DEPENDENT_AMOUNT,
   });
 
   delegateViewTest({
     method: 'calculateNeededToTransformToDependent',
-    args: (dependent) => [dependent, DEPENDENT_AMOUNT],
+    args: () => [dependent.address, DEPENDENT_AMOUNT],
     returns: UNDERLYING_AMOUNT as any,
   });
 
   delegateTest({
     method: 'transformToUnderlying',
-    args: (dependent) => [dependent, DEPENDENT_AMOUNT, '0x0000000000000000000000000000000000000002'],
+    args: () => [dependent.address, DEPENDENT_AMOUNT, RECIPIENT],
     returns: UNDERLYING_AMOUNT as any,
   });
 
   delegateTest({
     method: 'transformToDependent',
-    args: (dependent) => [dependent, UNDERLYING_AMOUNT, '0x0000000000000000000000000000000000000002'],
+    args: () => [dependent.address, UNDERLYING_AMOUNT, RECIPIENT],
     returns: DEPENDENT_AMOUNT,
     specialArgAssertion: (args) => {
-      expect(args[0]).to.equal(DEPENDENT);
+      expect(args[0]).to.equal(dependent.address);
       expect(args[1]).to.have.lengthOf(1);
       expect(args[1][0].underlying).to.equal(UNDERLYING_AMOUNT[0].underlying);
       expect(args[1][0].amount).to.equal(UNDERLYING_AMOUNT[0].amount);
-      expect(args[2]).to.equal('0x0000000000000000000000000000000000000002');
+      expect(args[2]).to.equal(RECIPIENT);
     },
+  });
+
+  describe('transformAllToUnderlying', () => {
+    assertFailsWithUnknownDependent('transformAllToUnderlying', () => [dependent.address, RECIPIENT]);
+    when('dependent is registered', () => {
+      given(async () => {
+        await registry.connect(governor).registerTransformers([{ transformer: transformer.address, dependents: [dependent.address] }]);
+        transformer.transformToUnderlying.returns(UNDERLYING_AMOUNT);
+        dependent.balanceOf.returns(DEPENDENT_AMOUNT);
+        await registry.transformAllToUnderlying(dependent.address, RECIPIENT);
+      });
+      then('balance of is called correctly', async () => {
+        expect(dependent.balanceOf).to.have.been.calledOnceWith(signer.address);
+      });
+      then('delegation worked as expected', async () => {
+        expect(transformer.transformToUnderlying)
+          .to.have.been.calledOnceWith(dependent.address, DEPENDENT_AMOUNT, RECIPIENT)
+          .delegatedFrom(registry.address);
+      });
+      then('return value from transformer is returned through registry', async () => {
+        const result = await registry.callStatic.transformAllToUnderlying(dependent.address, RECIPIENT);
+        expectObjectToBeTheSame(result, UNDERLYING_AMOUNT);
+      });
+    });
   });
 
   delegateTest({
     method: 'transformToExpectedUnderlying',
-    args: (dependent) => [dependent, UNDERLYING_AMOUNT, '0x0000000000000000000000000000000000000002'],
+    args: () => [dependent.address, UNDERLYING_AMOUNT, RECIPIENT],
     returns: DEPENDENT_AMOUNT,
     specialArgAssertion: (args) => {
-      expect(args[0]).to.equal(DEPENDENT);
+      expect(args[0]).to.equal(dependent.address);
       expect(args[1]).to.have.lengthOf(1);
       expect(args[1][0].underlying).to.equal(UNDERLYING_AMOUNT[0].underlying);
       expect(args[1][0].amount).to.equal(UNDERLYING_AMOUNT[0].amount);
-      expect(args[2]).to.equal('0x0000000000000000000000000000000000000002');
+      expect(args[2]).to.equal(RECIPIENT);
     },
   });
 
   delegateTest({
     method: 'transformToExpectedDependent',
-    args: (dependent) => [dependent, DEPENDENT_AMOUNT, '0x0000000000000000000000000000000000000002'],
+    args: () => [dependent.address, DEPENDENT_AMOUNT, RECIPIENT],
     returns: UNDERLYING_AMOUNT as any,
   });
 
@@ -205,18 +234,18 @@ describe('TransformerRegistry', () => {
     returns,
   }: {
     method: Method;
-    args: (dependent: string) => Parameters<Functions[Method]>;
+    args: () => Parameters<Functions[Method] & TransformerRegistry['functions'][Method]>;
     returns: Arrayed<Awaited<ReturnType<Functions[Method]>>> | Awaited<ReturnType<Functions[Method]>>;
   }) {
     describe(method, () => {
       assertFailsWithUnknownDependent(method, args);
       when('dependent is registered', () => {
         given(async () => {
-          await registry.connect(governor).registerTransformers([{ transformer: transformer.address, dependents: [DEPENDENT] }]);
+          await registry.connect(governor).registerTransformers([{ transformer: transformer.address, dependents: [dependent.address] }]);
           transformer[method].returns(returns);
         });
         then('return value from transformer is returned through registry', async () => {
-          const result = await (registry[method] as any)(...args(DEPENDENT));
+          const result = await (registry[method] as any)(...args());
           expectObjectToBeTheSame(result, returns);
         });
       });
@@ -230,7 +259,7 @@ describe('TransformerRegistry', () => {
     specialArgAssertion,
   }: {
     method: Method;
-    args: (dependent: string) => Parameters<Functions[Method]>;
+    args: () => Parameters<Functions[Method] & TransformerRegistry['functions'][Method]>;
     returns: Arrayed<Awaited<ReturnType<Functions[Method]>>> | Awaited<ReturnType<Functions[Method]>>;
     specialArgAssertion?: (args: any[]) => void;
   }) {
@@ -238,23 +267,23 @@ describe('TransformerRegistry', () => {
       assertFailsWithUnknownDependent(method, args);
       when('dependent is registered', () => {
         given(async () => {
-          await registry.connect(governor).registerTransformers([{ transformer: transformer.address, dependents: [DEPENDENT] }]);
+          await registry.connect(governor).registerTransformers([{ transformer: transformer.address, dependents: [dependent.address] }]);
           transformer[method].returns(returns);
         });
         then('delegation worked as expected', async () => {
-          await (registry[method] as any)(...args(DEPENDENT));
+          await (registry[method] as any)(...args());
           if (specialArgAssertion) {
             expect(transformer[method]).to.have.been.calledOnce.delegatedFrom(registry.address);
             const args = transformer[method].getCall(0).args as any[];
             specialArgAssertion(args);
           } else {
             expect(transformer[method])
-              .to.have.been.calledOnceWith(...args(DEPENDENT))
+              .to.have.been.calledOnceWith(...args())
               .delegatedFrom(registry.address);
           }
         });
         then('return value from transformer is returned through registry', async () => {
-          const result = await (registry.callStatic[method] as any)(...args(DEPENDENT));
+          const result = await (registry.callStatic[method] as any)(...args());
           expectObjectToBeTheSame(result, returns);
         });
       });
@@ -277,9 +306,9 @@ describe('TransformerRegistry', () => {
     }
   }
 
-  function assertFailsWithUnknownDependent<Method extends keyof Functions>(
+  function assertFailsWithUnknownDependent<Method extends keyof TransformerRegistry['functions']>(
     method: Method,
-    getArgs: (dependent: string) => Parameters<Functions[Method]>
+    getArgs: (dependent: string) => Parameters<TransformerRegistry['functions'][Method]>
   ) {
     when('trying to execute an action with an unregistered dependent', async () => {
       then('tx reverts with message', async () => {


### PR DESCRIPTION
We are now adding `transformAllToUnderlying`. It's almost the same as `transformToUnderlying`, but it will take all of the caller's balance